### PR TITLE
Always redirect if `allow` does not match

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = function(options) {
     var allowed = allow ? allow.test(pathname) : false;
     var hasFileExtension = !!(path.extname(pathname));
 
-    if (allowed || hasFileExtension) {
+    if (allowed || (!allow && hasFileExtension)) {
       next();
     } else {
       req.url = root;

--- a/test/pushstate-test.js
+++ b/test/pushstate-test.js
@@ -82,4 +82,32 @@ describe('pushState', function() {
       });
     });
   });
+
+  it('rewrites url if allow is given but not matched', function(done) {
+    var app = connect()
+      .use(pushState({ allow: '^/api' }))
+      .use(serveStatic(www));
+
+    var server = app.listen(3000).on('listening', function() {
+      request('http://0.0.0.0:3000/other/pathname', function(err, res, body) {
+        expect(res.statusCode).to.equal(200);
+        expect(body).to.contain('www/index.html');
+        server.close(done);
+      });
+    });
+  });
+
+  it('rewrites url with extension if allow is given but not matched', function(done) {
+    var app = connect()
+      .use(pushState({ allow: '^/api' }))
+      .use(serveStatic(www));
+
+    var server = app.listen(3000).on('listening', function() {
+      request('http://0.0.0.0:3000/other.csv', function(err, res, body) {
+        expect(res.statusCode).to.equal(200);
+        expect(body).to.contain('www/index.html');
+        server.close(done);
+      });
+    });
+  });
 });


### PR DESCRIPTION
Ok, I've put something together: With this patch, if `allow` is specified but does not match, it always redirects, regardless of whether it looks like a filename.

I find this to be more consistent than adding another flag, but I'm aware that it might break for people relying on the current behavior. Please let me know if you would prefer to introduce a new option for this instead and I'll happily update this pull request.

Unrelated to this PR: I wasn't able to run the tests straight away because (1) grunt is not part of the `devDependencies` and (2) jshint fails with the message `Warning: Path must be a string. Received null Use --force to continue.`. However, I made sure the new tests are actually testing the right thing.